### PR TITLE
Update to include .ts/.tsx test files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -477,7 +477,7 @@
   },
   "overrides": [
     {
-      "files": ["*.test.js", "*.test.jsx", "tests/**"],
+      "files": ["*.test.js", "*.test.jsx", "*.test.ts", "*.test.tsx", "tests/**"],
       "globals": {
         "after": true,
         "afterAll": true,


### PR DESCRIPTION
`.ts` and `.tsx` tests are throwing `max-nested-callbacks` issues with our linter. This PR includes those files.