### PR TITLE
Add Typescript rules

### DIFF
--- a/configs/.eslintrc.json
+++ b/configs/.eslintrc.json
@@ -475,7 +475,8 @@
         "onlyEquality": false
       }
     ],
-    "@typescript-eslint/member-delimiter-style": 2
+    "@typescript-eslint/member-delimiter-style": 2,
+    "@typescript-eslint/type-annotation-spacing": 2
   },
   "overrides": [
     {

--- a/configs/.eslintrc.json
+++ b/configs/.eslintrc.json
@@ -474,7 +474,8 @@
         "exceptRange": false,
         "onlyEquality": false
       }
-    ]
+    ],
+    "@typescript-eslint/member-delimiter-style": 2
   },
   "overrides": [
     {


### PR DESCRIPTION
#### Summary
Enable `@typscript-eslint/member-delimiter-style` and `@typescript-eslint/type-annotation-spacing` as discussed in the webapp guild meeting

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31327
https://mattermost.atlassian.net/browse/MM-31328

