### PR TITLE
[MM-31329] Enable @typescript-eslint/array-type

### DIFF
--- a/configs/.eslintrc.json
+++ b/configs/.eslintrc.json
@@ -475,6 +475,7 @@
         "onlyEquality": false
       }
     ],
+    "@typescript-eslint/array-type": [2, {"default": "array-simple"}],
     "@typescript-eslint/member-delimiter-style": 2,
     "@typescript-eslint/type-annotation-spacing": 2
   },


### PR DESCRIPTION
#### Summary
Enable `@typescript-eslint/array-type` with `array-simple` as discussed in the webapp guild meeting.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31329
