### PR TITLE
Added Import Sort Rule to Eslint Config

### DIFF
--- a/configs/.eslintrc.json
+++ b/configs/.eslintrc.json
@@ -424,7 +424,12 @@
         "after": true
       }
     ],
-    "sort-imports": 0,
+    "sort-imports": ["error", {
+      "ignoreCase": false,
+      "ignoreDeclarationSort": true,
+      "ignoreMemberSort": false,
+      "memberSyntaxSortOrder": ["none", "all", "single", "multiple"]
+    }],
     "sort-keys": 0,
     "space-before-blocks": [
       2,


### PR DESCRIPTION
Signed-off-by: Adithya Krishna <aadithya794@gmail.com>

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Adds Import Sort Rule to Eslint Config

#### Ticket Link
This PR Addresses https://github.com/mattermost/mattermost-app-zendesk/issues/77#issuecomment-914335178

I've added this rule so that in case this specific config is used, we will have a uniform Import Sort Rule

