### PR TITLE
[MM-50819] Add rule to enforce usage of new component

### DIFF
--- a/configs/.eslintrc.json
+++ b/configs/.eslintrc.json
@@ -164,6 +164,7 @@
       }
     ],
     "mattermost/no-dispatch-getstate": 2,
+    "mattermost/use-external-link": 2,
     "max-lines": [
       1,
       {

--- a/configs/.eslintrc.json
+++ b/configs/.eslintrc.json
@@ -164,7 +164,6 @@
       }
     ],
     "mattermost/no-dispatch-getstate": 2,
-    "mattermost/use-external-link": 2,
     "max-lines": [
       1,
       {

--- a/index.js
+++ b/index.js
@@ -16,5 +16,6 @@ module.exports = {
     },
     rules: {
         'no-dispatch-getstate': require('./rules/no-dispatch-getstate'),
+        'use-external-link': require('./rules/use-external-link'),
     },
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-mattermost",
+  "name": "eslint-plugin-mattermost",
   "version": "1.0.0",
   "description": "ESLint configuration used by Mattermost",
   "repository": {
@@ -8,5 +8,9 @@
   },
   "author": "Mattermost, Inc.",
   "license": "Apache 2.0",
-  "private": true
+  "private": true,
+  "dependencies": {
+    "eslint-plugin-jsx-a11y": "^6.7.1",
+    "jsx-ast-utils": "^3.3.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "private": true,
   "dependencies": {
     "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-mattermost": "github:mattermost/eslint-plugin-mattermost#f8ca36be5ceb398a9b1c343251f19d27c89eeb6b",
     "jsx-ast-utils": "^3.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "private": true,
   "dependencies": {
     "eslint-plugin-jsx-a11y": "^6.7.1",
-    "eslint-plugin-mattermost": "github:mattermost/eslint-plugin-mattermost#f8ca36be5ceb398a9b1c343251f19d27c89eeb6b",
     "jsx-ast-utils": "^3.3.3"
   }
 }

--- a/rules/no-dispatch-getstate.js
+++ b/rules/no-dispatch-getstate.js
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-const astUtils = require('eslint/lib/rules/utils/ast-utils');
-
 module.exports = {
     meta: {
         type: 'problem',
@@ -14,7 +12,6 @@ module.exports = {
     create(context) {
         function checkDispatch(node) {
             const args = node.arguments;
-
             if (args.length === 2) {
                 context.report({
                     node,

--- a/rules/use-external-link.js
+++ b/rules/use-external-link.js
@@ -31,7 +31,7 @@ module.exports =  {
                 const hasSpreadOperator = attributes.some((prop) => prop.type === 'JSXSpreadAttribute');
 
                 // When there is no target value at all, this rule does not apply:
-                if (!hasBlankTarget || hasSpreadOperator) {
+                if (!hasBlankTarget && hasSpreadOperator) {
                     return;
                 }
 

--- a/rules/use-external-link.js
+++ b/rules/use-external-link.js
@@ -1,0 +1,50 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+const astUtils = require('jsx-ast-utils')
+const getElementType = require('eslint-plugin-jsx-a11y/lib/util/getElementType')
+
+module.exports =  {
+    meta: {
+        docs: {
+            description: 'Enforce all anchors with target="_blank" to use ExternalLink component',
+        },
+    },
+
+create: (context) => {
+    const elementType = getElementType(context);
+        return {
+            JSXOpeningElement: (node) => {
+                const { attributes } = node;
+                const options = context.options[0] || {};
+                const componentOptions = options.components || [];
+                const typeCheck = ['a'].concat(componentOptions);
+                const nodeType = elementType(node);
+                // Only check anchor elements and custom types.
+                if (typeCheck.indexOf(nodeType) === -1) {
+                    return;
+                }
+
+                const propOptions = options.specialLink || [];
+                const propsToValidate = ['target'].concat(propOptions);
+                const values = propsToValidate.map((prop) => astUtils.getPropValue(astUtils.getProp(node.attributes, prop)));
+                // Checks if the target attribute is set to _blank (ie, is an external link)
+                const hasAnyTarget = values.some((value) => value != null && value === '_blank');
+                // Need to check for spread operator as props can be spread onto the element
+                // leading to an incorrect validation error.
+                const hasSpreadOperator = attributes.some((prop) => prop.type === 'JSXSpreadAttribute');
+
+                // When there is no target value at all, this rule does not apply:
+                if (!hasAnyTarget || hasSpreadOperator) {
+                    return;
+                }
+
+                context.report({
+                    node,
+                    message: 'Use ExternalLink component (components/external_link) for _blank target link-outs',
+                });
+                return
+            },
+        };
+    },
+};

--- a/rules/use-external-link.js
+++ b/rules/use-external-link.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 const astUtils = require('jsx-ast-utils')
+const getElementType = require('eslint-plugin-jsx-a11y/lib/util/getElementType')
 
 module.exports =  {
     meta: {
@@ -11,15 +12,18 @@ module.exports =  {
     },
 
 create: (context) => {
+    const elementType = getElementType(context);
         return {
             JSXOpeningElement: (node) => {
                 const { attributes } = node;
                 const typeCheck = 'a';
-                // Only check anchor elements and custom types.
-                if (typeCheck === nodeType) {
+                const nodeType = elementType(node);
+                // Only check anchor elements
+                if (typeCheck !== nodeType) {
                     return;
                 }
-                const propsToValidate = ['target']
+
+                const propsToValidate = ['target'];
                 const values = propsToValidate.map((prop) => astUtils.getPropValue(astUtils.getProp(node.attributes, prop)));
                 // Checks if the target attribute is set to _blank (ie, is an external link)
                 const hasAnyTarget = values.some((value) => value != null && value === '_blank');

--- a/rules/use-external-link.js
+++ b/rules/use-external-link.js
@@ -26,12 +26,9 @@ module.exports =  {
                 const values = propsToValidate.map((prop) => astUtils.getPropValue(astUtils.getProp(node.attributes, prop)));
                 // Checks if the target attribute is set to _blank (ie, is an external link)
                 const hasBlankTarget = values.some((value) => value != null && value === '_blank');
-                // Need to check for spread operator as props can be spread onto the element
-                // leading to an incorrect validation error.
-                const hasSpreadOperator = attributes.some((prop) => prop.type === 'JSXSpreadAttribute');
 
                 // When there is no target value at all, this rule does not apply:
-                if (!hasBlankTarget && hasSpreadOperator) {
+                if (!hasBlankTarget) {
                     return;
                 }
 

--- a/rules/use-external-link.js
+++ b/rules/use-external-link.js
@@ -19,7 +19,7 @@ create: (context) => {
                 const typeCheck = 'a';
                 const nodeType = elementType(node);
                 // Only check anchor elements
-                if (typeCheck !== nodeType) {
+                if (!nodeType || typeCheck !== nodeType) {
                     return;
                 }
 

--- a/rules/use-external-link.js
+++ b/rules/use-external-link.js
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 const astUtils = require('jsx-ast-utils')
-const getElementType = require('eslint-plugin-jsx-a11y/lib/util/getElementType')
 
 module.exports =  {
     meta: {
@@ -12,21 +11,15 @@ module.exports =  {
     },
 
 create: (context) => {
-    const elementType = getElementType(context);
         return {
             JSXOpeningElement: (node) => {
                 const { attributes } = node;
-                const options = context.options[0] || {};
-                const componentOptions = options.components || [];
-                const typeCheck = ['a'].concat(componentOptions);
-                const nodeType = elementType(node);
+                const typeCheck = 'a';
                 // Only check anchor elements and custom types.
-                if (typeCheck.indexOf(nodeType) === -1) {
+                if (typeCheck === nodeType) {
                     return;
                 }
-
-                const propOptions = options.specialLink || [];
-                const propsToValidate = ['target'].concat(propOptions);
+                const propsToValidate = ['target']
                 const values = propsToValidate.map((prop) => astUtils.getPropValue(astUtils.getProp(node.attributes, prop)));
                 // Checks if the target attribute is set to _blank (ie, is an external link)
                 const hasAnyTarget = values.some((value) => value != null && value === '_blank');

--- a/rules/use-external-link.js
+++ b/rules/use-external-link.js
@@ -10,9 +10,8 @@ module.exports =  {
             description: 'Enforce all anchors with target="_blank" to use ExternalLink component',
         },
     },
-
-create: (context) => {
-    const elementType = getElementType(context);
+    create: (context) => {
+        const elementType = getElementType(context);
         return {
             JSXOpeningElement: (node) => {
                 const { attributes } = node;
@@ -26,13 +25,13 @@ create: (context) => {
                 const propsToValidate = ['target'];
                 const values = propsToValidate.map((prop) => astUtils.getPropValue(astUtils.getProp(node.attributes, prop)));
                 // Checks if the target attribute is set to _blank (ie, is an external link)
-                const hasAnyTarget = values.some((value) => value != null && value === '_blank');
+                const hasBlankTarget = values.some((value) => value != null && value === '_blank');
                 // Need to check for spread operator as props can be spread onto the element
                 // leading to an incorrect validation error.
                 const hasSpreadOperator = attributes.some((prop) => prop.type === 'JSXSpreadAttribute');
 
                 // When there is no target value at all, this rule does not apply:
-                if (!hasAnyTarget || hasSpreadOperator) {
+                if (!hasBlankTarget || hasSpreadOperator) {
                     return;
                 }
 


### PR DESCRIPTION
#### Summary
We want to be able to [enrich link-outs from mattermost to *.mattermost.com with contextual information](https://mattermost.atlassian.net/browse/MM-50467). This will help us to identify PQL's. This lint rule is intended to enforce usage of a new wrapper component `ExternalLink` (PR incoming) for any usage of an anchor tag with `target='_blank'`

Implementation of this rule was inspired by the `anchor-is-valid` rule from `jsx-a11y`
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50467
